### PR TITLE
Use schema of the request instead of static http.

### DIFF
--- a/src/main/java/org/jahia/modules/saml2/SAML2Util.java
+++ b/src/main/java/org/jahia/modules/saml2/SAML2Util.java
@@ -47,9 +47,10 @@ public class SAML2Util {
         if (StringUtils.isEmpty(serverName)) {
             serverName = request.getServerName();
         }
-        url.append("http://").append(serverName);
+        url.append(request.getScheme()).append("://").append(serverName).append(incoming);
+        
 
-        return "http://" + serverName + incoming;
+        return url.toString();
     }
 
     /**


### PR DESCRIPTION
Use scheme of the request to generate the AssertionConsumerServiceUrl instead of a static HTT scheme.