### PR TITLE
Use server port of request for SAML redirect URL

### DIFF
--- a/src/main/java/org/jahia/modules/saml2/SAML2Util.java
+++ b/src/main/java/org/jahia/modules/saml2/SAML2Util.java
@@ -32,7 +32,7 @@ public final class SAML2Util {
         }
 
         try {
-            URL url = new URL(request.getScheme(), serverName, request.getLocalPort(), request.getContextPath() + incoming);
+            URL url = new URL(request.getScheme(), serverName, request.getServerPort(), request.getContextPath() + incoming);
             return url.toString();
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/SELENIUM-1509

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Use port specified in the request for the SAML redirect URL, not local port. This was causing issue when request port is different from internal port within a cluster config.