### PR TITLE
QA-14304: update user properties if SAML properties are not null/empty

### DIFF
--- a/src/main/java/org/jahia/modules/saml2/actions/SAMLCallback.java
+++ b/src/main/java/org/jahia/modules/saml2/actions/SAMLCallback.java
@@ -137,7 +137,8 @@ public class SAMLCallback extends Action {
     private boolean updateUserProperties(JCRNodeWrapper jcrNodeWrapper, Map<String, Object> mapperResult) throws RepositoryException {
         boolean isUpdated = false;
         for (Map.Entry<String, Object> entry : mapperResult.entrySet()) {
-            if (Objects.isNull(jcrNodeWrapper.getPropertyAsString(entry.getKey())) || !jcrNodeWrapper.getPropertyAsString(entry.getKey()).equals(entry.getValue())) {
+            if (Objects.isNull(jcrNodeWrapper.getPropertyAsString(entry.getKey())) || 
+                    (!Objects.isNull(entry.getValue()) && !jcrNodeWrapper.getPropertyAsString(entry.getKey()).equals(entry.getValue()))) {
                 jcrNodeWrapper.setProperty(entry.getKey(), (String) entry.getValue());
                 isUpdated = true;
             }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14304

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Now, we only update the user properties if the user properties sent back by "SAML" are not null/empty

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
