### PR TITLE
Added missing timeout

### DIFF
--- a/.github/workflows/nightly-standalone-release.yml
+++ b/.github/workflows/nightly-standalone-release.yml
@@ -26,6 +26,7 @@ jobs:
           module_id: saml-authentication-valve
           incident_service: saml-authentication-valve-JahiaRL
           testrail_project: SAML Module
+          timeout_minutes: 30
           tests_manifest: provisioning-manifest-release.yml
           jahia_image: jahia/jahia-discovery:8
           should_use_build_artifacts: false

--- a/.github/workflows/nightly-standalone-snapshot.yml
+++ b/.github/workflows/nightly-standalone-snapshot.yml
@@ -26,6 +26,7 @@ jobs:
           module_id: saml-authentication-valve
           incident_service: saml-authentication-valve-JahiaSN
           testrail_project: SAML Module
+          timeout_minutes: 30
           tests_manifest: provisioning-manifest-snapshot.yml
           jahia_image: jahia/jahia-discovery-dev:8-SNAPSHOT
           should_use_build_artifacts: false

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -74,7 +74,8 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: saml-authentication-valve
-          testrail_project: SAML Authentication Valve
+          testrail_project: SAML Module
+          timeout_minutes: 30
           testrail_milestone: Default
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -68,7 +68,8 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: content-editor
-          testrail_project: Content Editor
+          testrail_project: SAML Module
+          timeout_minutes: 30
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8
           should_use_build_artifacts: true


### PR DESCRIPTION
Without this timeout, GitHub Actions might shut down the job before it got a chance to send pagerduty notifications or collect artifacts.