### PR TITLE
TECH-1416: Fix guava import for compatibility with Jahia 8.1 and 8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <pac4j.version>4.5.4</pac4j.version>
         <opensaml.version>3.4.6</opensaml.version>
-        <google.guava.version>31.0.1-jre</google.guava.version>
         <cryptacular.version>1.2.4</cryptacular.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <joda-time.version>2.9.9</joda-time.version>
@@ -158,12 +157,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${google.guava.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.cryptacular</groupId>
             <artifactId>cryptacular</artifactId>
             <version>${cryptacular.version}</version>
@@ -274,7 +267,17 @@
                     <instructions>
                         <Jahia-Depends>jahia-authentication</Jahia-Depends>
                         <Embed-Transitive>false</Embed-Transitive>
-                        <Import-Package>org.springframework.core.io;version="[3.2,4)",${jahia.plugin.projectPackageImport},*</Import-Package>
+                        <Import-Package>
+                            ${jahia.plugin.projectPackageImport},
+                            org.springframework.core.io;version="[3.2,4)",
+                            com.google.common.base;version="[30.1,34)",
+                            com.google.common.cache;version="[30.1,34)",
+                            com.google.common.collect;version="[30.1,34)",
+                            com.google.common.escape;version="[30.1,34)",
+                            com.google.common.io;version="[30.1,34)",
+                            com.google.common.net;version="[30.1,34)",
+                            *
+                        </Import-Package>
                         <_noimportjava>true</_noimportjava>
                     </instructions>
                 </configuration>

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node18.12.0-chrome106-ff106
+FROM cypress/browsers:node-20.10.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
 
 RUN apt update && apt install -yq jq curl
 RUN adduser --disabled-password jahians


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1416

## Description

Set Guava OSGI Range from 30.1 to 34 in pom to ensure compatibility with jahia 8.1 and 8.2

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation