### PR TITLE
TECH-1737: Use JDK8 image in sonar wf

### DIFF
--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
          supported_branches: ["${{ github.event.repository.default_branch }}"]
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1737

## Description

We'll only use JDK11 in the Sonar workflow when the module will be built with this image