### PR TITLE
fix: remove mixin used in test that does not exist in version of Jahia prior to 8.2.1.0

### DIFF
--- a/tests/cypress/fixtures/samlLogin/createSamlButton.graphql
+++ b/tests/cypress/fixtures/samlLogin/createSamlButton.graphql
@@ -4,7 +4,7 @@ mutation createSamlButton($homePath: String!, $name: String!) {
             parentPathOrId: $homePath,
             name:"pagecontent",
             primaryNodeType:"jnt:contentList",
-            mixins:["jmix:systemNameReadonly","jmix:isAreaList"])
+            mixins:["jmix:systemNameReadonly"])
         {
             addChild(name: $name, primaryNodeType:"jnt:samlLogin") {
                 uuid


### PR DESCRIPTION
### Description

SAML nightly on Release (8.1.8.2) is failing due to mixin used in tests that is not present in that version of Jahia.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
