### PR TITLE
chore: bump commons-beanutils version from 1.9.4 to 1.11.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,23 @@
         <sonar.sources>src/main/resources/javascript</sonar.sources>
     </properties>
 
-
     <scm>
         <connection>scm:git:git@github.com:Jahia/saml-authentication-valve.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/saml-authentication-valve.git</developerConnection>
         <url>scm:git:git@github.com:Jahia/saml-authentication-valve.git</url>
         <tag>HEAD</tag>
     </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- remove that specific commons-beanutils version when parent (jahia-modules) will be upgraded to version >= 8.2.3.0 -->
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.11.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -301,7 +311,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
 
     </dependencies>
 


### PR DESCRIPTION
### Description

Upgrade commons-beanutils from version 1.9.4 to version 1.11.0

The commons-beanutils 1.9.4 version is also provided by jahia-impl 8.1.3.0
In jahia-impl, version has been bumped to 1.11.0 in the commit (078bcb81c0271009f508ebfaa066fb0a66417859) 
Thus, even if dependency is now upgraded in the module using a specific dependency-management, it should be removed when module's parent will switch to a version >= 8.2.3.0.
