### PR TITLE
chore: updated jahia parent from 8.1.3.0 to 8.2.3.0 and jahia-authentication from 1.7.0 to 2.0.0

### DIFF
--- a/.chachalog/q22VTAY_.md
+++ b/.chachalog/q22VTAY_.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+saml-authentication-valve: major
+---
+
+Updated jahia parent from 8.1.3.0 to 8.2.3.0, jahia-authentication from 1.7.0 to 2.0.0 and bumped the module version to 4.0.0 (#179)

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -32,7 +32,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -26,7 +26,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
          supported_branches: ["${{ github.event.repository.default_branch }}"]
     container:
-      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     </description>
 
     <properties>
+        <jahia-depends>jahia-authentication</jahia-depends>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <pac4j.version>4.5.7</pac4j.version>
         <opensaml.version>3.4.6</opensaml.version>
@@ -24,8 +25,6 @@
         <joda-time.version>2.12.7</joda-time.version>
         <java-support.version>7.5.2</java-support.version>
         <jahia-module-signature>MCwCFEQl8cCw9WVWj9HnM1KxBSF4bYSFAhQ0cVi+hN3epYSL8Lx7kNHtUUEjIw==</jahia-module-signature>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
         <sonar.sources>src/main/resources/javascript</sonar.sources>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,16 +35,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- remove that specific commons-beanutils version when parent (jahia-modules) will be upgraded to version >= 8.2.3.0 -->
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>1.11.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -292,7 +282,7 @@
         <dependency>
             <groupId>org.jahia.server</groupId>
             <artifactId>jahia-impl</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -360,10 +350,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
@@ -394,11 +381,6 @@
                     <outputName>java-bom.cdx</outputName>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>io.github.git-commit-id</groupId>
-                <artifactId>git-commit-id-maven-plugin</artifactId>
-                <version>5.0.0</version>
-            </plugin>            
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>net.shibboleth.utilities</groupId>
             <artifactId>java-support</artifactId>
             <version>${java-support.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,8 @@
                         <Import-Package>
                             ${jahia.plugin.projectPackageImport},
                             !org.apache.log4j.*,
+                            !org.apache.logging.log4j.*,
+                            !org.slf4j.impl,
                             com.google.common.base;version="[30.1,34)",
                             com.google.common.cache;version="[30.1,34)",
                             com.google.common.collect;version="[30.1,34)",

--- a/pom.xml
+++ b/pom.xml
@@ -394,6 +394,11 @@
                     <outputName>java-bom.cdx</outputName>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
+            </plugin>            
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <java-support.version>7.5.2</java-support.version>
         <jahia-module-signature>MCwCFEQl8cCw9WVWj9HnM1KxBSF4bYSFAhQ0cVi+hN3epYSL8Lx7kNHtUUEjIw==</jahia-module-signature>
         <jahia.plugin.version>6.9</jahia.plugin.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <sonar.sources>src/main/resources/javascript</sonar.sources>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>jahia-modules</artifactId>
@@ -35,7 +36,6 @@
         <tag>HEAD</tag>
     </scm>
 
-
     <dependencies>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -56,7 +56,7 @@
             <version>2.12.2</version>
         </dependency>
 
-       <dependency>
+        <dependency>
             <groupId>org.pac4j</groupId>
             <artifactId>pac4j-saml-opensamlv3</artifactId>
             <version>${pac4j.version}</version>
@@ -77,6 +77,22 @@
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-1.2-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-jcl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -84,6 +100,12 @@
             <groupId>org.pac4j</groupId>
             <artifactId>pac4j-core</artifactId>
             <version>${pac4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -332,9 +354,6 @@
                         <Jahia-Depends>jahia-authentication</Jahia-Depends>
                         <Import-Package>
                             ${jahia.plugin.projectPackageImport},
-                            !org.apache.log4j.*,
-                            !org.apache.logging.log4j.*,
-                            !org.slf4j.impl,
                             com.google.common.base;version="[30.1,34)",
                             com.google.common.cache;version="[30.1,34)",
                             com.google.common.collect;version="[30.1,34)",

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,10 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.spy</groupId>
+                    <artifactId>spymemcached</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -286,6 +290,12 @@
             <groupId>org.apache.velocity.tools</groupId>
             <artifactId>velocity-tools-generic</artifactId>
             <version>3.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,7 @@
                         <Jahia-Depends>jahia-authentication</Jahia-Depends>
                         <Import-Package>
                             ${jahia.plugin.projectPackageImport},
+                            !org.apache.log4j.*,
                             com.google.common.base;version="[30.1,34)",
                             com.google.common.cache;version="[30.1,34)",
                             com.google.common.collect;version="[30.1,34)",

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
         <joda-time.version>2.12.7</joda-time.version>
         <java-support.version>7.5.2</java-support.version>
         <jahia-module-signature>MCwCFEQl8cCw9WVWj9HnM1KxBSF4bYSFAhQ0cVi+hN3epYSL8Lx7kNHtUUEjIw==</jahia-module-signature>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <sonar.sources>src/main/resources/javascript</sonar.sources>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.3.0</version>
+        <version>8.2.3.0</version>
     </parent>
 
     <artifactId>saml-authentication-valve</artifactId>
     <name>SAML Authentication Valve</name>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (SAML Authentication Valve) for running on a Digital Experience Manager
         server.
@@ -23,7 +23,7 @@
         <bouncycastle.version>1.84</bouncycastle.version>
         <joda-time.version>2.12.7</joda-time.version>
         <java-support.version>7.5.2</java-support.version>
-        <jahia-module-signature>MC0CFQCMBOF4RxlW5XDKwCQCZ+8v62/DtwIUCjA/rxiIAbxWY7itj4cMcji6LqI=</jahia-module-signature>
+        <jahia-module-signature>MCwCFEQl8cCw9WVWj9HnM1KxBSF4bYSFAhQ0cVi+hN3epYSL8Lx7kNHtUUEjIw==</jahia-module-signature>
         <jahia.plugin.version>6.9</jahia.plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -281,7 +281,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-authentication</artifactId>
-            <version>1.7.0</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/provisioning-manifest-build-8.2.x.yml
+++ b/tests/provisioning-manifest-build-8.2.x.yml
@@ -1,8 +1,10 @@
 - karafCommand: "bundle:list"
 
 - installBundle:
-  - 'mvn:org.jahia.modules/jahia-authentication/RELEASE'
-  - 'mvn:org.jahia.modules/jcr-auth-provider/RELEASE'
+  # The range should include the jahia-authentication version defined in the pom.xml
+  - 'mvn:org.jahia.modules/jahia-authentication/[2.0-SNAPSHOT,3.0-SNAPSHOT)'
+  # Use the version range of jcr-auth-provider compatible with the jahia-authentication version above
+  - 'mvn:org.jahia.modules/jcr-auth-provider/[4.0-SNAPSHOT,5.0-SNAPSHOT)'
   - 'mvn:org.jahia.modules/contact'
   - 'mvn:org.jahia.modules/event'
   - 'mvn:org.jahia.modules/font-awesome'

--- a/tests/provisioning-manifest-snapshot-8.2.x.yml
+++ b/tests/provisioning-manifest-snapshot-8.2.x.yml
@@ -1,6 +1,8 @@
 - installBundle:
-  - 'mvn:org.jahia.modules/jahia-authentication/RELEASE'
-  - 'mvn:org.jahia.modules/jcr-auth-provider/[3.0-SNAPSHOT,4.0-SNAPSHOT)'
+  # The range should include the jahia-authentication version defined in the pom.xml
+  - 'mvn:org.jahia.modules/jahia-authentication/[2.0-SNAPSHOT,3.0-SNAPSHOT)'
+  # Use the version range of jcr-auth-provider compatible with the jahia-authentication version above
+  - 'mvn:org.jahia.modules/jcr-auth-provider/[4.0-SNAPSHOT,5.0-SNAPSHOT)'
   - 'mvn:org.jahia.modules/contact'
   - 'mvn:org.jahia.modules/event'
   - 'mvn:org.jahia.modules/font-awesome'


### PR DESCRIPTION
It is necessary to release a new version to be compatible with jahia-authentication 2.0.0.

See: https://github.com/Jahia/jcr-auth-provider/issues/77#issuecomment-4682117301