### PR TITLE
ci: use static network config for containers

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -16,8 +16,12 @@ services:
         ports:
             - '389:389'
             - '636:636'
+        extra_hosts:
+            - "jahia:172.18.0.10"
+            - "keycloak:172.18.0.11"
         networks:
-            - stack
+            default:
+                ipv4_address: 172.18.0.12
 
     keycloak:
         image: quay.io/keycloak/keycloak:21.0
@@ -37,8 +41,12 @@ services:
             # external port needs to be same as docker internal port (8080) for generating idp-metadata.xml
             - '8080:8080'
         command: 'start-dev --import-realm'
+        extra_hosts:
+            - "jahia:172.18.0.10"
+            - "ldap:172.18.0.12"
         networks:
-            - stack
+            default:
+                ipv4_address: 172.18.0.11
 
     jahia:
         image: '${JAHIA_IMAGE}'
@@ -53,8 +61,12 @@ services:
         ports:
             - '8081:8080'
             - '8000:8000'
+        extra_hosts:
+            - "jahia:172.18.0.10"
+            - "keycloak:172.18.0.11"
         networks:
-            - stack
+            default:
+                ipv4_address: 172.18.0.10
 
     # Cypress container
     cypress:
@@ -71,7 +83,14 @@ services:
             - NEXUS_USERNAME=${NEXUS_USERNAME}
             - NEXUS_PASSWORD=${NEXUS_PASSWORD}
         networks:
-            - stack
+            default:
+                ipv4_address: 172.18.0.20
+        extra_hosts:
+            - "jahia:172.18.0.10"
+            - "keycloak:172.18.0.11"
 
 networks:
-    stack:
+    default:
+        ipam:
+            config:
+                - subnet: 172.18.0.0/16


### PR DESCRIPTION
### Description

This pull request updates the `tests/docker-compose.yml` file to improve network configuration and service connectivity for the test environment. The main changes assign fixed IP addresses to key services and add `extra_hosts` entries to ensure reliable hostname resolution between containers. This setup helps prevent network-related issues in integration tests and facilitates communication among services.

**Network configuration improvements:**

* Changed the network from a custom `stack` network to a `default` network with a specified subnet (`172.18.0.0/16`), and assigned static IP addresses to the `ldap`, `keycloak`, `jahia`, and `cypress` services. [[1]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R19-R24) [[2]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R44-R49) [[3]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R64-R69) [[4]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732L74-R96)

**Service connectivity enhancements:**

* Added `extra_hosts` entries for each service to map service names to their static IPs, ensuring containers can resolve each other's hostnames correctly (`jahia`, `keycloak`, `ldap`). [[1]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R19-R24) [[2]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R44-R49) [[3]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R64-R69) [[4]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732L74-R96)


